### PR TITLE
Image preview panels fails for Orthoview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*asv
+directory.mat

--- a/includes/tools/zSlicer/zSlicer_time.m
+++ b/includes/tools/zSlicer/zSlicer_time.m
@@ -74,7 +74,19 @@ data{varargin{7}} = im;
 handles.data = data;
 handles.input = varargin;
 
-set(handles.slider_z, 'Value', 1, 'Min', 1, 'Max', handles.maxZ, 'SliderStep', [1/(handles.maxZ-1), 1/(handles.maxZ-1)]);
+
+
+handles.slider_z.Value = 1;
+handles.slider_z.Min = 1;
+handles.slider_z.Max = handles.maxZ;
+
+if handles.slider_z.Max == 1
+    handles.slider_z.Visible = 'off';
+    handles.text7.Visible = 'off';
+else
+     handles.slider_z.SliderStep = [1/(handles.maxZ-1), 1/(handles.maxZ-1)];
+end
+
 sliderStep = 1/(numel(varargin{3})-1) * [1 1];
 if ~sliderStep(1) || isinf(sliderStep(1))
     sliderStep = [1 1];

--- a/tests/tools/zSlicer/test_zSlicer_time.m
+++ b/tests/tools/zSlicer/test_zSlicer_time.m
@@ -1,0 +1,34 @@
+function tests = test_zSlicer_time
+    tests = functiontests(localfunctions);
+end
+
+function teardown(testCase)  % do not change function name
+    close('all');
+end
+
+%% Test zSlicer 2D
+function test2D_inputData(testCase)
+    maxZ = 1;
+    im = randi([0, 1], [4,4,maxZ]);
+    maxZ = 1;
+    handles.settings.lists.files_tif = {'dummy.tif'};
+    timepoints = {datetime};
+    workingDir = 'dummy';
+    metadata.data.scaling.dxy = 1;
+    metadata.data.scaling.dz = 1;
+    file = 1;
+    zSlicer_time(im, maxZ, handles.settings.lists.files_tif, timepoints, workingDir, metadata.data.scaling, file);
+end
+
+%% Test zSlicer 3D
+function test3D_inputData(testCase)
+    maxZ = 4;
+    im = randi([0, 1], [4,4,maxZ]);
+    handles.settings.lists.files_tif = {'dummy.tif'};
+    timepoints = {datetime};
+    workingDir = 'dummy';
+    metadata.data.scaling.dxy = 1;
+    metadata.data.scaling.dz = 1;
+    file = 1;
+    zSlicer_time(im, maxZ, handles.settings.lists.files_tif, timepoints, workingDir, metadata.data.scaling, file);
+end

--- a/tests/tools/zSlicer/test_zSlicer_time.m
+++ b/tests/tools/zSlicer/test_zSlicer_time.m
@@ -2,10 +2,6 @@ function tests = test_zSlicer_time
     tests = functiontests(localfunctions);
 end
 
-function teardown(testCase)  % do not change function name
-    close('all');
-end
-
 %% Test zSlicer 2D
 function test2D_inputData(testCase)
     maxZ = 1;
@@ -17,7 +13,8 @@ function test2D_inputData(testCase)
     metadata.data.scaling.dxy = 1;
     metadata.data.scaling.dz = 1;
     file = 1;
-    zSlicer_time(im, maxZ, handles.settings.lists.files_tif, timepoints, workingDir, metadata.data.scaling, file);
+    h = zSlicer_time(im, maxZ, handles.settings.lists.files_tif, timepoints, workingDir, metadata.data.scaling, file);
+    close(h.figure1)
 end
 
 %% Test zSlicer 3D
@@ -30,5 +27,6 @@ function test3D_inputData(testCase)
     metadata.data.scaling.dxy = 1;
     metadata.data.scaling.dz = 1;
     file = 1;
-    zSlicer_time(im, maxZ, handles.settings.lists.files_tif, timepoints, workingDir, metadata.data.scaling, file);
+    h = zSlicer_time(im, maxZ, handles.settings.lists.files_tif, timepoints, workingDir, metadata.data.scaling, file);
+    close(h.figure1)
 end


### PR DESCRIPTION
When 2D data is used, the orthoview button fails due to division by zero in the slider settings.

- Created testcase
- Fixed issue by deactivating the slider completely