### PR TITLE
Add export tif tab for segmentation data

### DIFF
--- a/BiofilmQ.m
+++ b/BiofilmQ.m
@@ -372,6 +372,7 @@ handles = populateTabs(handles, 'uipanel_workflow_segmentation_mergeAndTransfer'
 
 set(handles.splashScreenHandle,'ProgressRatio', 0.25)
 
+handles.layout.uipanels.uipanel_workflow_dataExport_seg = uipanel_workflow_dataExport_seg(handles);
 
 handles.layout.tabs.workflow_exportTabs = uitabgroup('Parent', handles.layout.uipanels.uipanel_workflow_dataExport_methodTabs.Parent, 'TabLocation', 'top', 'units', 'characters', 'Position', get(handles.layout.uipanels.uipanel_workflow_dataExport_methodTabs, 'Position'));
 delete(handles.layout.uipanels.uipanel_workflow_dataExport_methodTabs)

--- a/BiofilmQ.m
+++ b/BiofilmQ.m
@@ -380,6 +380,7 @@ delete(handles.layout.uipanels.uipanel_workflow_dataExport_methodTabs)
 handles = populateTabs(handles, 'uipanel_workflow_dataExport_vtk','workflow_exportTabs');
 handles = populateTabs(handles, 'uipanel_workflow_dataExport_fcs','workflow_exportTabs');
 handles = populateTabs(handles, 'uipanel_workflow_dataExport_csv','workflow_exportTabs');
+handles = populateTabs(handles, 'uipanel_workflow_dataExport_seg','workflow_exportTabs');
 
 set(handles.splashScreenHandle,'ProgressRatio', 0.3)
 
@@ -477,6 +478,7 @@ set(handles.splashScreenHandle,'ProgressRatio', 0.6)
 handles = replaceUIPanel(handles, 'uipanel_workflow_dataExport');
 handles = replaceUIPanel(handles, 'uipanel_workflow_dataExport_vtk');
 handles = replaceUIPanel(handles, 'uipanel_workflow_dataExport_fcs');
+handles = replaceUIPanel(handles, 'uipanel_workflow_dataExport_seg');
 
 set(handles.splashScreenHandle,'ProgressRatio', 0.65)
 

--- a/includes/export/segmentation/Callbacks/dataExport_seg_export_Callback.m
+++ b/includes/export/segmentation/Callbacks/dataExport_seg_export_Callback.m
@@ -1,0 +1,33 @@
+function dataExport_seg_export_Callback(hObject, eventdata, handles)
+
+    seg_data_files = handles.settings.lists.files_cells;
+   
+    name_matches_placeholder = regexp( ...
+        {seg_data_files.name}, ...
+        '^missing_ch\d+$', 'once');
+    
+    is_segmented_frame = cellfun(@isempty, name_matches_placeholder);
+    
+    segmented_frames = find(is_segmented_frame);
+    selected_frames = str2num(handles.uicontrols.edit.action_imageRange.String);
+    
+    valid_frames = intersect(segmented_frames, selected_frames);
+    
+    output_folder = fullfile(handles.settings.directory, 'data', 'seg_output');
+    
+    if ~isfolder(output_folder)
+        mkdir(output_folder)
+    end
+
+    for frame = valid_frames
+        filename = seg_data_files(frame).name;
+        filepath = fullfile(seg_data_files(frame).folder, filename);
+        objects = load(filepath);
+        w = labelmatrix(objects);
+        
+        output_name = strrep(filename, '_data.mat', '.tif');
+        imwrite3D(w, fullfile(output_folder, output_name));
+    end
+
+end
+

--- a/includes/export/segmentation/Callbacks/dataExport_seg_export_Callback.m
+++ b/includes/export/segmentation/Callbacks/dataExport_seg_export_Callback.m
@@ -1,3 +1,20 @@
+% Copyright (c) 2021 Eric Jelli (GitHub: @erjel)
+%
+% This program is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program.  If not, see <http://www.gnu.org/licenses/>.
+%
+%%
+
 function dataExport_seg_export_Callback(hObject, eventdata, handles)
     %% Export start boilerplate
     ticValueAll = displayTime;

--- a/includes/export/segmentation/Callbacks/dataExport_seg_export_Callback.m
+++ b/includes/export/segmentation/Callbacks/dataExport_seg_export_Callback.m
@@ -1,5 +1,10 @@
 function dataExport_seg_export_Callback(hObject, eventdata, handles)
+    %% Export start boilerplate
+    ticValueAll = displayTime;
+    toggleBusyPointer(handles, true)
+    fprintf('=========== Exporting to TIF ===========\n');
 
+    %%
     seg_data_files = handles.settings.lists.files_cells;
    
     name_matches_placeholder = regexp( ...
@@ -9,25 +14,62 @@ function dataExport_seg_export_Callback(hObject, eventdata, handles)
     is_segmented_frame = cellfun(@isempty, name_matches_placeholder);
     
     segmented_frames = find(is_segmented_frame);
-    selected_frames = str2num(handles.uicontrols.edit.action_imageRange.String);
+    selected_frames_str = handles.uicontrols.edit.action_imageRange.String;
+    selected_frames = str2num(selected_frames_str);
     
     valid_frames = intersect(segmented_frames, selected_frames);
     
     output_folder = fullfile(handles.settings.directory, 'data', 'seg_output');
     
+    
     if ~isfolder(output_folder)
         mkdir(output_folder)
     end
-
-    for frame = valid_frames
+    fprintf('Output folder: %s\n', output_folder);
+    
+    n_frames = numel(valid_frames);
+    for i = 1:n_frames
+        frame = valid_frames(i);
+        
+        %% File operation boilerplate
+        handles.java.files_jtable.changeSelection(frame-1, 0, false, false);
+            
+        ticValueImage = displayTime;
+        fprintf('Image %d of %d (Frame %d): ', ...
+            i, n_frames, frame);
+    
+        updateWaitbar(handles, i/(1+n_frames));
+        
+        %% 
         filename = seg_data_files(frame).name;
         filepath = fullfile(seg_data_files(frame).folder, filename);
         objects = load(filepath);
+        
         w = labelmatrix(objects);
         
+        %% More file operation boilerplate
+        displayStatus(handles, 'saving TIF-file...', 'blue', 'add');
+        updateWaitbar(handles, (i+0.6)/(1+n_frames));
+        
+        %%
         output_name = strrep(filename, '_data.mat', '.tif');
-        imwrite3D(w, fullfile(output_folder, output_name));
-    end
+        imwrite3D(w, fullfile(output_folder, output_name), [], true);
+        
+        %% End file operation boilerplate
+        displayStatus(handles, 'Done', 'blue', 'add');
+        fprintf('-> total elapsed time per image')
+        displayTime(ticValueImage);
 
+        if checkCancelButton(handles)
+            return;
+        end
+    end
+    
+    %% Export start boilerplate
+    updateWaitbar(handles, 0);
+    fprintf('-> total elapsed time')
+    displayTime(ticValueAll);
+    
+    toggleBusyPointer(handles, false)
 end
 

--- a/includes/export/segmentation/uipanel_workflow_dataExport_seg.m
+++ b/includes/export/segmentation/uipanel_workflow_dataExport_seg.m
@@ -1,36 +1,47 @@
 function p = uipanel_workflow_dataExport_seg(handles)
 
-    test = true;
+    test = false;
     
     padding = 8;
     spacing = 8;
     objectHeight = 22;
     
-    p = uipanel('Title', 'Export Segmentation (tif)');
+    p = uipanel('Title', 'Segmentation (TIF-files)');
     
     if test
         f = figure(1);
         p.Parent = f;
+    else
+        p.Parent = handles.mainFig;
     end
    
     %% Elements
-    handles.uicontrols.pushbutton.dataExport_seg_export = ...
+    handles.uicontrols.pushbutton.pushbutton_dataExport_seg_export = ...
         uicontrol( ...
         'Tag', 'dataExport_seg_export_pushbutton', ...
         'Style', 'pushbutton', ...
-        'String', 'Export' ...
-        );
+        'String', 'Export', ...
+        'FontSize', 10 ...
+    );
+    
+    handles.uicontrols.text.text_workflow_dataExport_seg_descr = ...
+        uicontrol( ...
+        'Tag', 'dataExport_seg_descr', ...
+        'Style', 'text', ...
+        'String', 'Object segmentations can be exported into the TIF-format', ...
+        'FontAngle', 'italic', ...
+        'HorizontalAlignment', 'left' ...
+    );
 
-    %% Layout        
-    v1 = uix.VBox('Parent', p, 'Padding', 0, 'Spacing', spacing);
-        v1_h1 = uix.HBox('Parent', v1, 'Padding', 0, 'Spacing', spacing);
-            uix.VBox('Parent', v1_h1, 'Tag', 'EmptyPlaceholder');
-            handles.uicontrols.pushbutton.dataExport_seg_export.Parent = v1_h1;
+    %% Layout
+    h = uix.HBox('Parent', p);
+    handles.uicontrols.text.text_workflow_dataExport_seg_descr.Parent = h;
+    h_button = uix.HButtonBox('Parent', h, 'Spacing', spacing, 'HorizontalAlignment', 'right', 'VerticalAlignment', 'top', 'ButtonSize', [150 objectHeight]);
+    handles.uicontrols.pushbutton.pushbutton_dataExport_seg_export.Parent = h_button;
+    
 
-        v1_h1.Widths = [-1, 150];
-    v1.Heights =  0.85*objectHeight*ones(numel(v1.Children));
 
     %% Callbacks
-    handles.uicontrols.pushbutton.dataExport_seg_export.Callback = ...
+    handles.uicontrols.pushbutton.pushbutton_dataExport_seg_export.Callback = ...
         @(hObject, eventdata) dataExport_seg_export_Callback(hObject, eventdata, guidata(handles.mainFig)); 
 end

--- a/includes/export/segmentation/uipanel_workflow_dataExport_seg.m
+++ b/includes/export/segmentation/uipanel_workflow_dataExport_seg.m
@@ -15,9 +15,10 @@
 %
 %%
 
-function p = uipanel_workflow_dataExport_seg(handles)
-
-    test = false;
+function p = uipanel_workflow_dataExport_seg(handles, test)
+    if nargin == 1
+        test = false;
+    end
     
     padding = 8;
     spacing = 8;

--- a/includes/export/segmentation/uipanel_workflow_dataExport_seg.m
+++ b/includes/export/segmentation/uipanel_workflow_dataExport_seg.m
@@ -1,3 +1,20 @@
+% Copyright (c) 2021 Eric Jelli (GitHub: @erjel)
+%
+% This program is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program.  If not, see <http://www.gnu.org/licenses/>.
+%
+%%
+
 function p = uipanel_workflow_dataExport_seg(handles)
 
     test = false;

--- a/includes/export/segmentation/uipanel_workflow_dataExport_seg.m
+++ b/includes/export/segmentation/uipanel_workflow_dataExport_seg.m
@@ -1,0 +1,36 @@
+function p = uipanel_workflow_dataExport_seg(handles)
+
+    test = true;
+    
+    padding = 8;
+    spacing = 8;
+    objectHeight = 22;
+    
+    p = uipanel('Title', 'Export Segmentation (tif)');
+    
+    if test
+        f = figure(1);
+        p.Parent = f;
+    end
+   
+    %% Elements
+    handles.uicontrols.pushbutton.dataExport_seg_export = ...
+        uicontrol( ...
+        'Tag', 'dataExport_seg_export_pushbutton', ...
+        'Style', 'pushbutton', ...
+        'String', 'Export' ...
+        );
+
+    %% Layout        
+    v1 = uix.VBox('Parent', p, 'Padding', 0, 'Spacing', spacing);
+        v1_h1 = uix.HBox('Parent', v1, 'Padding', 0, 'Spacing', spacing);
+            uix.VBox('Parent', v1_h1, 'Tag', 'EmptyPlaceholder');
+            handles.uicontrols.pushbutton.dataExport_seg_export.Parent = v1_h1;
+
+        v1_h1.Widths = [-1, 150];
+    v1.Heights =  0.85*objectHeight*ones(numel(v1.Children));
+
+    %% Callbacks
+    handles.uicontrols.pushbutton.dataExport_seg_export.Callback = ...
+        @(hObject, eventdata) dataExport_seg_export_Callback(hObject, eventdata, guidata(handles.mainFig)); 
+end

--- a/includes/layout/replaceUIPanel.m
+++ b/includes/layout/replaceUIPanel.m
@@ -1746,6 +1746,9 @@ switch panelName
             handles.uicontrols.pushbutton.importCustomTiffPushbutton.Callback = ...
                 @(hObject,eventdata)BiofilmQ('importCustomTiffPushbutton_Callback',hObject,eventdata,guidata(hObject));
         end
+    otherwise
+        h = uix.HBox('Parent', handles.layout.uipanels.(panelName).Parent, 'Padding', 2*padding, 'Spacing', spacing);
+        handles.layout.uipanels.(panelName).Children.Parent = h;
 end
 
 try

--- a/tests/includes/export/segmentation/test_uipanel_workflow_dataExport_seg.m
+++ b/tests/includes/export/segmentation/test_uipanel_workflow_dataExport_seg.m
@@ -1,0 +1,90 @@
+function tests = test_uipanel_workflow_dataExport_seg
+    tests = functiontests(localfunctions);
+end
+
+%% Overloaded test setup functions
+function setup(testCase)
+    % setup test dir
+    testCase.TestData.origPath = pwd;
+    testCase.TestData.tmpFolder = ['tmpFolder' datestr(now,30)];
+    mkdir(testCase.TestData.tmpFolder)
+    cd(testCase.TestData.tmpFolder)
+    
+    % required parameters
+    handles.mainFig = figure(2);
+    handles.settings.lists.files_cells = dir('*_data.mat');
+    handles.uicontrols.edit.action_imageRange.String = '1:2';
+    handles.settings.directory = testCase.TestData.tmpFolder;
+    
+    % boilerplate handles for output
+    handles.uitables.files = uitable();
+    handles.java.files_javaHandle = findjobj(handles.uitables.files);
+    jscrollpane = javaObjectEDT(handles.java.files_javaHandle);
+    viewport    = javaObjectEDT(jscrollpane.getViewport);
+    jtable      = javaObjectEDT(viewport.getView);
+    handles.java.files_jtable = jtable;
+    
+    handles.uicontrols.listbox.listbox_status = uicontrol('Style', 'text');
+    
+    % populate boilerplate handles
+    handles.uitables.files.Data = {handles.settings.lists.files_cells.name};
+    
+    guidata(handles.mainFig, handles);
+    
+    testCase.TestData.handles = handles;
+end
+
+function teardown(testCase)
+    cd(testCase.TestData.origPath)
+    rmdir(testCase.TestData.tmpFolder, 's')
+    
+    open_figures = findall(groot,'Type','figure');
+    for i = 1:numel(open_figures)
+        close(open_figures(i))
+    end
+end
+
+%% Custom helper function
+function create_mock_files(size)
+    % create mock files
+    for i = str2num('1:2')
+        seg_img = randi(2, size) - 1;
+        objects = conncomp(seg_img);
+        objects.stats = regionprops(objects);
+        saveObjects(sprintf('test%d_data.mat', i), objects, 'all', 'init');
+    end
+end
+
+%% Actual tests
+function test_emptydir(testCase)
+    handles = testCase.TestData.handles;
+
+    test = true;
+    panel = uipanel_workflow_dataExport_seg(handles, test);
+
+    panel.Children.Children(1).Children.Callback([], [])
+end
+
+function test_simple_2D(testCase)
+    imageSize = [10, 10];
+    create_mock_files(imageSize)
+    
+    handles = testCase.TestData.handles;
+
+    test = true;
+    panel = uipanel_workflow_dataExport_seg(handles, test);
+
+    panel.Children.Children(1).Children.Callback([], [])
+end
+
+function test_simple_3D(testCase)
+    imageSize = [10, 10, 10];
+    create_mock_files(imageSize)
+
+    handles = testCase.TestData.handles;
+
+    test = true;
+    panel = uipanel_workflow_dataExport_seg(handles, test);
+
+    panel.Children.Children(1).Children.Callback([], [])
+end

--- a/tests/includes/export/segmentation/test_uipanel_workflow_dataExport_seg.m
+++ b/tests/includes/export/segmentation/test_uipanel_workflow_dataExport_seg.m
@@ -1,3 +1,20 @@
+% Copyright (c) 2021 Eric Jelli (GitHub: @erjel)
+%
+% This program is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program.  If not, see <http://www.gnu.org/licenses/>.
+%
+%%
+
 function tests = test_uipanel_workflow_dataExport_seg
     tests = functiontests(localfunctions);
 end


### PR DESCRIPTION
A lot of code for a simple for loop ...

- Created new tab in the export workflow tab
- Implemented tif export from labelmatrix
- Added standard boilerplate code for verbosity/ status updates/ Update of the waitbar

Missing:

- [x] Tests (at least for the export function)
- [x] Licence comment